### PR TITLE
extend add_file to work with str, bytes and generator data sources

### DIFF
--- a/encapsia_api/package.py
+++ b/encapsia_api/package.py
@@ -36,30 +36,40 @@ class PackageMaker:
         """Return the manifest as a dictionary."""
         return toml.load(self.directory / "package.toml")
 
-    def add_file(self, name, data_source, mode=None):
+    def _add_file(self, name, chunks, mode):
         """Add a file to the package of given name containing given data."""
         self._files.append(name)
         filename = self.directory / name
         filename.parent.mkdir(parents=True, exist_ok=True)
-        if isinstance(data_source, types.GeneratorType):
-            if mode is None:
-                raise ValueError(
-                    "Must provide write mode (t or b) suitable for "
-                    "data returned by data_source"
-                )
-            chunks = data_source
-        else:
-            if isinstance(data_source, str):
-                mode = "t"
-            elif isinstance(data_source, bytes):
-                mode = "b"
-            else:
-                type_ = type(data_source).__name__
-                raise ValueError(f"Don't know how to write data of type {type_}")
-            chunks = (data_source, )
         with filename.open(f"w{mode}") as f:
             for chunk in chunks:
                 f.write(chunk)
+
+    def add_file(self, name, data):
+        """Add a file to the package of given name containing given data.
+
+        data should be a string object.
+        """
+        self._add_file(name, (data, ), "t")
+
+    def add_file_from_bytes(self, name, data):
+        """Add a file to the package of given name containing given data.
+
+        data should be a bytes object.
+        """
+        self._add_file(name, (data, ), "b")
+
+    def add_file_from_chunks(self, name, chunks, mode=None):
+        """Add a file to the package of given name containing given data.
+
+        data should be an iterable returning chunks of the file's data.
+        """
+        if mode not in ("t", "b"):
+            raise ValueError(
+                "Must provide write mode (t or b) suitable for "
+                "data returned by data_source"
+            )
+        self._add_file(name, chunks, mode)
 
     def make_package(self, directory=pathlib.Path("/tmp/ice")):
         """Return .tar.gz of newly created package in given directory."""

--- a/encapsia_api/package.py
+++ b/encapsia_api/package.py
@@ -48,21 +48,21 @@ class PackageMaker:
     def add_file(self, name, data):
         """Add a file to the package of given name containing given data.
 
-        data should be a string object.
+        ``data`` should be a string object.
         """
         self._add_file(name, (data, ), "t")
 
     def add_file_from_bytes(self, name, data):
         """Add a file to the package of given name containing given data.
 
-        data should be a bytes object.
+        ``data`` should be a bytes object.
         """
         self._add_file(name, (data, ), "b")
 
     def add_file_from_chunks(self, name, chunks, mode=None):
-        """Add a file to the package of given name containing given data.
+        """Add a file to the package of given name containing given data in chunks.
 
-        data should be an iterable returning chunks of the file's data.
+        ``chunks`` should be an iterable returning chunks of the file's data.
         """
         if mode not in ("t", "b"):
             raise ValueError(


### PR DESCRIPTION
Usage would be:

```
from encapsia_api import package
maker = package.PackageMaker("foopack")
maker.add_file("fromtext", "abc\n")
maker.add_file("frombytes", b"abc\n")

def chunker():
    for _ in range(5):
        yield "abc\n"

maker.add_file("fromchunks", chunker(), mode="t")
maker.make_package(directory=".")
```

The two new use cases are present in some of the packages Roxana is creating:
* ability to add data that is obtained as bytes
* ability to get data in batches, for large amounts of data