### PR TITLE
properly parse the content-type header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (Nothing yet)
 
+## [0.2.6=7] - 2021-01-19
+
+### Fixed
+
+- Fix bug where the "Content-type" header for views returning CSV also has the charset option ("text/csv; charset=UTF-8").
+
 ## [0.2.6] - 2020-09-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (Nothing yet)
 
-## [0.2.6=7] - 2021-01-19
+## [0.2.7] - 2021-01-19
 
 ### Fixed
 

--- a/encapsia_api/__init__.py
+++ b/encapsia_api/__init__.py
@@ -1,5 +1,5 @@
 #: Keep in sync with git tag and package version in pyproject.toml.
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 
 class EncapsiaApiError(RuntimeError):  # NOQA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encapsia-api"
-version = "0.2.6"
+version = "0.2.7"
 description = "Client API for talking to an Encapsia system."
 readme = "README.md"
 authors = ["Timothy Corbett-Clark <timothy.corbettclark@gmail.com>"]


### PR DESCRIPTION
This fixes the behaviour when the content type reply is "Content-type: text/csv; charset=UTF-8".