### PR TITLE
Only explicitly and safely overwrite file in make_package(). Closes #39

### DIFF
--- a/encapsia_api/lib.py
+++ b/encapsia_api/lib.py
@@ -1,6 +1,7 @@
 import contextlib
 import mimetypes
 import pathlib
+import os
 import shutil
 import tarfile
 import tempfile
@@ -65,6 +66,18 @@ def temp_dir(cleanup=True):
     finally:
         if cleanup:
             shutil.rmtree(directory)
+
+
+@contextlib.contextmanager
+def make_temp_file_path(delete_after=True):
+    fd, name = tempfile.mkstemp()
+    os.close(fd)
+    path = pathlib.Path(name)
+    try:
+        yield path
+    finally:
+        if delete_after:
+            path.unlink(missing_ok=True)
 
 
 @contextlib.contextmanager

--- a/encapsia_api/package.py
+++ b/encapsia_api/package.py
@@ -10,6 +10,9 @@ from typing import Iterable
 
 import toml
 
+from encapsia_api.lib import make_temp_file_path
+
+
 __all__ = ["PackageMaker"]
 
 
@@ -145,7 +148,7 @@ class PackageMaker:
             f"package-{type_name}-{instance_name}-{instance_version}.tar.gz"
         )
 
-    def make_package(self, directory=pathlib.Path("/tmp")):
+    def make_package(self, directory=pathlib.Path("/tmp"), overwrite=False):
         """Return .tar.gz of newly created package in given directory."""
         self._add_manifest()
         filename = directory / self.package_filename
@@ -158,9 +161,12 @@ class PackageMaker:
             tarinfo.name = name
             return tarinfo
 
-        with tarfile.open(filename, "w:gz") as tar:
-            # Just doing tar.add(self.directory) creates problems with empty top level directory.
-            # So iterate through the top level files and directories.
-            for f in self.directory.iterdir():
-                tar.add(f, filter=strip_root_dir)
-        return filename
+        with make_temp_file_path() as temp_file:
+            with tarfile.open(temp_file, "w:gz") as tar:
+                # Just doing tar.add(self.directory) creates problems with empty top level directory.
+                # So iterate through the top level files and directories.
+                for f in self.directory.iterdir():
+                    tar.add(f, filter=strip_root_dir)
+            if filename.exists() and not overwrite:
+                raise FileExistsError(f"{filename} already exists.")
+            return pathlib.Path(temp_file).replace(filename)


### PR DESCRIPTION
Prevent overwriting an existing file, in `PackageMaker.make_package()`, by default. 
Overwriting can still be requested explicitly (e.g. for LAP encrypt/decrypt "in place"). 

Safely create a temporary file and move it in place when ready.

closes #39