### PR TITLE
Only explicitly and safely overwrite file in make_package()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
-- Switch to localStorage
+### Changed
+
+- Switch token management to localStorage
+
+### Added
+
+- Add an overwrite flag to make_package so that we only explicitly overwrite an existing package
 
 ## [0.2.9] - 2021-03-10
 

--- a/encapsia_api/lib.py
+++ b/encapsia_api/lib.py
@@ -1,7 +1,7 @@
 import contextlib
 import mimetypes
-import pathlib
 import os
+import pathlib
 import shutil
 import tarfile
 import tempfile

--- a/encapsia_api/lib.py
+++ b/encapsia_api/lib.py
@@ -77,7 +77,11 @@ def make_temp_file_path(delete_after=True):
         yield path
     finally:
         if delete_after:
-            path.unlink(missing_ok=True)
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                # Use path.unlink(missing_ok=True) once we stop supporting <3.8
+                pass
 
 
 @contextlib.contextmanager

--- a/encapsia_api/lib.py
+++ b/encapsia_api/lib.py
@@ -1,6 +1,7 @@
 import contextlib
 import mimetypes
 import pathlib
+import os
 import shutil
 import tarfile
 import tempfile
@@ -65,6 +66,18 @@ def temp_dir(cleanup=True):
     finally:
         if cleanup:
             shutil.rmtree(directory)
+
+
+@contextlib.contextmanager
+def make_temp_file_path(delete_after=True):
+    fd, name = tempfile.mkstemp()
+    os.close(fd)
+    path = pathlib.Path(name)
+    try:
+        yield path
+    finally:
+        if delete_after:
+            path.unlink(missing_ok=True)
 
 
 @contextlib.contextmanager

--- a/encapsia_api/package.py
+++ b/encapsia_api/package.py
@@ -10,6 +10,9 @@ from typing import Iterable
 
 import toml
 
+from encapsia_api.lib import make_temp_file_path
+
+
 __all__ = ["PackageMaker"]
 
 
@@ -145,7 +148,7 @@ class PackageMaker:
             f"package-{type_name}-{instance_name}-{instance_version}.tar.gz"
         )
 
-    def make_package(self, directory=pathlib.Path("/tmp")):
+    def make_package(self, directory=pathlib.Path("/tmp"), overwrite=False):
         """Return .tar.gz of newly created package in given directory."""
         self._add_manifest()
         filename = directory / self.package_filename
@@ -158,9 +161,12 @@ class PackageMaker:
             tarinfo.name = name
             return tarinfo
 
-        with tarfile.open(filename, "w:gz") as tar:
-            # Just doing tar.add(self.directory) creates problems with empty top level directory.
-            # So iterate through the top level files and directories.
-            for f in self.directory.iterdir():
-                tar.add(f, filter=strip_root_dir)
-        return filename
+        with make_temp_file_path() as temp_file:
+            with tarfile.open(temp_file, "w:gz") as tar:
+                # Just doing tar.add(self.directory) creates problems with empty top level directory.
+                # So iterate through the top level files and directories.
+                for f in self.directory.iterdir():
+                    tar.add(f, filter=strip_root_dir)
+            if filename.exists() and not overwrite:
+                raise FileExistsError(f"{filename} already exists.")
+            return pathlib.Path(temp_file).replace(filename)

--- a/encapsia_api/package.py
+++ b/encapsia_api/package.py
@@ -12,7 +12,6 @@ import toml
 
 from encapsia_api.lib import make_temp_file_path
 
-
 __all__ = ["PackageMaker"]
 
 

--- a/encapsia_api/package.py
+++ b/encapsia_api/package.py
@@ -169,4 +169,6 @@ class PackageMaker:
                     tar.add(f, filter=strip_root_dir)
             if filename.exists() and not overwrite:
                 raise FileExistsError(f"{filename} already exists.")
-            return pathlib.Path(temp_file).replace(filename)
+            temp_file.replace(filename)
+            # With python>=3.8, we can also return the result of Path.replace()
+            return filename

--- a/encapsia_api/tests/test_package.py
+++ b/encapsia_api/tests/test_package.py
@@ -66,9 +66,8 @@ class TestPackageMaker:
         assert m["package_format"] == "1.0"
         assert sorted(m.keys()) == sorted(["package_format", "type", "instance"])
         assert sorted(m["type"].keys()) == sorted(["description", "name", "format"])
-        assert (
-            sorted(m["instance"].keys())
-            == sorted(["name", "description", "version", "created_by", "created_on"])
+        assert sorted(m["instance"].keys()) == sorted(
+            ["name", "description", "version", "created_by", "created_on"]
         )
         assert m["type"]["name"] == M["type"]["name"]
         assert m["type"]["format"] == M["type"]["format"]
@@ -88,9 +87,8 @@ class TestPackageMaker:
             p.add_file_from_string("b.txt", "bar")
             filename = p.make_package(tmp_path)
             with tarfile.open(filename, mode="r:gz") as tar:
-                assert (
-                    set(m.name for m in tar.getmembers())
-                    == set(["a.txt", "b.txt", "package.toml"])
+                assert set(m.name for m in tar.getmembers()) == set(
+                    ["a.txt", "b.txt", "package.toml"]
                 )
 
     def test_add_files_from_directory(self, tmp_path):
@@ -125,9 +123,8 @@ class TestPackageMaker:
         dir_content = list(tmp_path.iterdir())
         assert dir_content == [filename]
         with tarfile.open(filename, mode="r:gz") as tar:
-            assert (
-                set(m.name for m in tar.getmembers())
-                == set(["a.txt", "package.toml"])
+            assert set(m.name for m in tar.getmembers()) == set(
+                ["a.txt", "package.toml"]
             )
             assert tar.extractfile("a.txt").read().decode() == "foo"
 
@@ -142,8 +139,7 @@ class TestPackageMaker:
         dir_content = list(tmp_path.iterdir())
         assert dir_content == [filename1]
         with tarfile.open(filename1, mode="r:gz") as tar:
-            assert (
-                set(m.name for m in tar.getmembers())
-                == set(["a.txt", "package.toml"])
+            assert set(m.name for m in tar.getmembers()) == set(
+                ["a.txt", "package.toml"]
             )
             assert tar.extractfile("a.txt").read().decode() == "bar"

--- a/encapsia_api/tests/test_package.py
+++ b/encapsia_api/tests/test_package.py
@@ -1,39 +1,38 @@
-import pathlib
 import tarfile
-import tempfile
-import unittest
+
+import pytest
 
 from encapsia_api import package
 
 
-class TestMakeValidName(unittest.TestCase):
+class TestMakeValidName:
     def test_empty(self):
-        self.assertEqual(package._make_valid_name(""), "")
+        assert package._make_valid_name("") == ""
 
     def test_already_valid(self):
-        self.assertEqual(package._make_valid_name("abc"), "abc")
-        self.assertEqual(package._make_valid_name("aBc"), "aBc")
-        self.assertEqual(package._make_valid_name("ABc"), "ABc")
-        self.assertEqual(package._make_valid_name("ABc123"), "ABc123")
-        self.assertEqual(package._make_valid_name("ABc_123"), "ABc_123")
+        assert package._make_valid_name("abc") == "abc"
+        assert package._make_valid_name("aBc") == "aBc"
+        assert package._make_valid_name("ABc") == "ABc"
+        assert package._make_valid_name("ABc123") == "ABc123"
+        assert package._make_valid_name("ABc_123") == "ABc_123"
 
     def test_hypens(self):
-        self.assertEqual(package._make_valid_name("ABc-123"), "ABc_123")
-        self.assertEqual(package._make_valid_name("-ABc-123"), "_ABc_123")
-        self.assertEqual(package._make_valid_name("-ABc-123-"), "_ABc_123_")
+        assert package._make_valid_name("ABc-123") == "ABc_123"
+        assert package._make_valid_name("-ABc-123") == "_ABc_123"
+        assert package._make_valid_name("-ABc-123-") == "_ABc_123_"
 
     def test_spaces(self):
-        self.assertEqual(package._make_valid_name("abc def"), "abc_def")
-        self.assertEqual(package._make_valid_name("  abc def"), "__abc_def")
-        self.assertEqual(package._make_valid_name("  abc def "), "__abc_def_")
+        assert package._make_valid_name("abc def") == "abc_def"
+        assert package._make_valid_name("  abc def") == "__abc_def"
+        assert package._make_valid_name("  abc def ") == "__abc_def_"
 
     def test_newlines(self):
-        self.assertEqual(package._make_valid_name("abc\ndef"), "abcdef")
-        self.assertEqual(package._make_valid_name("\n\nabc\ndef"), "abcdef")
-        self.assertEqual(package._make_valid_name("\n\nabc\ndef\n"), "abcdef")
+        assert package._make_valid_name("abc\ndef") == "abcdef"
+        assert package._make_valid_name("\n\nabc\ndef") == "abcdef"
+        assert package._make_valid_name("\n\nabc\ndef\n") == "abcdef"
 
 
-class TestPackageMaker(unittest.TestCase):
+class TestPackageMaker:
 
     MANIFEST_FIELDS = dict(
         type=dict(name="test-type", format="1.0", description="whatever"),
@@ -45,88 +44,106 @@ class TestPackageMaker(unittest.TestCase):
 
     def test_supported_package_formats(self):
         package.PackageMaker("1.0", self.MANIFEST_FIELDS)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             package.PackageMaker("0.1", self.MANIFEST_FIELDS)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             package.PackageMaker("1.1", self.MANIFEST_FIELDS)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             package.PackageMaker("2.0", self.MANIFEST_FIELDS)
 
-    def test_make_empty_package(self):
+    def test_make_empty_package(self, tmp_path):
         with package.PackageMaker("1.0", self.MANIFEST_FIELDS) as p:
-            filename = p.make_package()
-            self.assertEqual(filename.name, self.PACKAGE_FILENAME)
+            filename = p.make_package(tmp_path)
+            assert filename.name == self.PACKAGE_FILENAME
             with tarfile.open(filename, mode="r:gz") as tar:
-                self.assertEqual(
-                    set(m.name for m in tar.getmembers()), set(["package.toml"])
-                )
+                assert set(m.name for m in tar.getmembers()) == set(["package.toml"])
 
-    def test_manifest_contents(self):
+    def test_manifest_contents(self, tmp_path):
         with package.PackageMaker("1.0", self.MANIFEST_FIELDS) as p:
-            filename = p.make_package()
+            filename = p.make_package(tmp_path)
         m = package.extract_manifest(filename)
         M = self.MANIFEST_FIELDS
-        self.assertEqual(m["package_format"], "1.0")
-        self.assertEqual(
-            sorted(m.keys()), sorted(["package_format", "type", "instance"])
+        assert m["package_format"] == "1.0"
+        assert sorted(m.keys()) == sorted(["package_format", "type", "instance"])
+        assert sorted(m["type"].keys()) == sorted(["description", "name", "format"])
+        assert (
+            sorted(m["instance"].keys())
+            == sorted(["name", "description", "version", "created_by", "created_on"])
         )
-        self.assertEqual(
-            sorted(m["type"].keys()), sorted(["description", "name", "format"])
-        )
-        self.assertEqual(
-            sorted(m["instance"].keys()),
-            sorted(["name", "description", "version", "created_by", "created_on"]),
-        )
-        self.assertEqual(m["type"]["name"], M["type"]["name"])
-        self.assertEqual(m["type"]["format"], M["type"]["format"])
-        self.assertEqual(
-            m["type"]["description"],
-            M["type"]["description"],
-        )
-        self.assertEqual(m["instance"]["name"], M["instance"]["name"])
-        self.assertEqual(
-            m["instance"]["version"],
-            M["instance"]["version"],
-        )
-        self.assertEqual(
-            m["instance"]["created_by"],
-            M["instance"]["created_by"],
-        )
+        assert m["type"]["name"] == M["type"]["name"]
+        assert m["type"]["format"] == M["type"]["format"]
+        assert m["type"]["description"] == M["type"]["description"]
+        assert m["instance"]["name"] == M["instance"]["name"]
+        assert m["instance"]["version"] == M["instance"]["version"]
+        assert m["instance"]["created_by"] == M["instance"]["created_by"]
 
     def test_cannot_overwrite_manifest_file(self):
         with package.PackageMaker("1.0", self.MANIFEST_FIELDS) as p:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 p.add_file_from_string("package.toml", "whatever")
 
-    def test_add_files_from_string(self):
+    def test_add_files_from_string(self, tmp_path):
         with package.PackageMaker("1.0", self.MANIFEST_FIELDS) as p:
             p.add_file_from_string("a.txt", "foo")
             p.add_file_from_string("b.txt", "bar")
-            filename = p.make_package()
+            filename = p.make_package(tmp_path)
             with tarfile.open(filename, mode="r:gz") as tar:
-                self.assertEqual(
-                    set(m.name for m in tar.getmembers()),
-                    set(["a.txt", "b.txt", "package.toml"]),
+                assert (
+                    set(m.name for m in tar.getmembers())
+                    == set(["a.txt", "b.txt", "package.toml"])
                 )
 
-    def test_add_files_from_directory(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_dir = pathlib.Path(tmp_dir)
-            (tmp_dir / "a.txt").write_text("foo")
-            (tmp_dir / "a_directory").mkdir()
-            (tmp_dir / "a_directory" / "b.txt").write_text("bar")
-            with package.PackageMaker("1.0", self.MANIFEST_FIELDS) as p:
-                p.add_all_files_from_directory(tmp_dir)
-                filename = p.make_package()
-                with tarfile.open(filename, mode="r:gz") as tar:
-                    self.assertEqual(
-                        set(m.name for m in tar.getmembers()),
-                        set(
-                            [
-                                "a.txt",
-                                "a_directory",
-                                "a_directory/b.txt",
-                                "package.toml",
-                            ]
-                        ),
-                    )
+    def test_add_files_from_directory(self, tmp_path):
+        tmp_dir = tmp_path / "source"
+        tmp_dir.mkdir()
+        (tmp_dir / "a.txt").write_text("foo")
+        (tmp_dir / "a_directory").mkdir()
+        (tmp_dir / "a_directory" / "b.txt").write_text("bar")
+        with package.PackageMaker("1.0", self.MANIFEST_FIELDS) as p:
+            p.add_all_files_from_directory(tmp_dir)
+            filename = p.make_package(tmp_path)
+            with tarfile.open(filename, mode="r:gz") as tar:
+                tar_files = set(m.name for m in tar.getmembers())
+                expected_files = set(
+                    [
+                        "a.txt",
+                        "a_directory",
+                        "a_directory/b.txt",
+                        "package.toml",
+                    ]
+                )
+                assert tar_files == expected_files
+
+    def test_make_same_package_fails(self, tmp_path):
+        with package.PackageMaker("1.0", self.MANIFEST_FIELDS) as p1:
+            p1.add_file_from_string("a.txt", "foo")
+            filename = p1.make_package(tmp_path)
+        with package.PackageMaker("1.0", self.MANIFEST_FIELDS) as p2:
+            p2.add_file_from_string("a.txt", "bar")
+            with pytest.raises(FileExistsError):
+                p2.make_package(tmp_path)
+        dir_content = list(tmp_path.iterdir())
+        assert dir_content == [filename]
+        with tarfile.open(filename, mode="r:gz") as tar:
+            assert (
+                set(m.name for m in tar.getmembers())
+                == set(["a.txt", "package.toml"])
+            )
+            assert tar.extractfile("a.txt").read().decode() == "foo"
+
+    def test_make_same_package_overwrites(self, tmp_path):
+        with package.PackageMaker("1.0", self.MANIFEST_FIELDS) as p1:
+            p1.add_file_from_string("a.txt", "foo")
+            filename1 = p1.make_package(tmp_path)
+        with package.PackageMaker("1.0", self.MANIFEST_FIELDS) as p2:
+            p2.add_file_from_string("a.txt", "bar")
+            filename2 = p2.make_package(tmp_path, overwrite=True)
+        assert filename1 == filename2
+        dir_content = list(tmp_path.iterdir())
+        assert dir_content == [filename1]
+        with tarfile.open(filename1, mode="r:gz") as tar:
+            assert (
+                set(m.name for m in tar.getmembers())
+                == set(["a.txt", "package.toml"])
+            )
+            assert tar.extractfile("a.txt").read().decode() == "bar"


### PR DESCRIPTION
* Add an `overwrite` flag to `make_package` so that we only explicitly overwrite an existing package
* Create the package in a temporary file and move in place once done
* Make package tests use pytest proper and its `tmp_path` fixture
* Adapt tests so that they don't write new package with same name in same location
* Add tests for `overwrite` flag

Closes #39 